### PR TITLE
make "int" to "intl", to not confuse irc-osric

### DIFF
--- a/lib/OSRIC/Character.pm
+++ b/lib/OSRIC/Character.pm
@@ -34,7 +34,6 @@ sub new
 	my $class = shift;
 	my $character =
 	{
-		irc => "", # The player's irc nick, not found on the character sheet.
 		personal =>
 		{
 			name => "",
@@ -74,13 +73,6 @@ sub new
 		},
 	};
 	bless $character, $class;
-}
-
-# Sets the player's irc nick:
-sub set_irc
-{
-	my $self = shift;
-	$self->{irc} = shift;
 }
 
 # Generates the 6 major stats:

--- a/lib/OSRIC/Character.pm
+++ b/lib/OSRIC/Character.pm
@@ -55,7 +55,7 @@ sub new
 			str => 0,
 			dex => 0,
 			con => 0,
-			int => 0,
+			intl => 0,
 			wis => 0,
 			cha => 0,
 		},

--- a/lib/OSRIC/Class/Assassin.pm
+++ b/lib/OSRIC/Class/Assassin.pm
@@ -17,7 +17,7 @@ sub minimum_scores
 		str => 12,
 		dex => 12,
 		con => 6,
-		int => 11,
+		intl => 11,
 		wis => 6,
 		cha => 0,
 	}

--- a/lib/OSRIC/Class/Cleric.pm
+++ b/lib/OSRIC/Class/Cleric.pm
@@ -17,7 +17,7 @@ sub minimum_scores
 		str => 6,
 		dex => 3,
 		con => 6,
-		int => 6,
+		intl => 6,
 		wis => 9,
 		cha => 6,
 	}

--- a/lib/OSRIC/Class/Druid.pm
+++ b/lib/OSRIC/Class/Druid.pm
@@ -17,7 +17,7 @@ sub minimum_scores
 		str => 6,
 		dex => 6,
 		con => 6,
-		int => 6,
+		intl => 6,
 		wis => 12,
 		cha => 15,
 	}

--- a/lib/OSRIC/Class/Fighter.pm
+++ b/lib/OSRIC/Class/Fighter.pm
@@ -17,7 +17,7 @@ sub minimum_scores
 		str => 9,
 		dex => 6,
 		con => 7,
-		int => 3,
+		intl => 3,
 		wis => 6,
 		cha => 6,
 	}

--- a/lib/OSRIC/Class/Illusionist.pm
+++ b/lib/OSRIC/Class/Illusionist.pm
@@ -17,7 +17,7 @@ sub minimum_scores
 		str => 6,
 		dex => 16,
 		con => 0,
-		int => 15,
+		intl => 15,
 		wis => 6,
 		cha => 6,
 	}

--- a/lib/OSRIC/Class/MagicUser.pm
+++ b/lib/OSRIC/Class/MagicUser.pm
@@ -17,7 +17,7 @@ sub minimum_scores
 		str => 3,
 		dex => 6,
 		con => 6,
-		int => 9,
+		intl => 9,
 		wis => 6,
 		cha => 6,
 	}

--- a/lib/OSRIC/Class/Paladin.pm
+++ b/lib/OSRIC/Class/Paladin.pm
@@ -17,7 +17,7 @@ sub minimum_scores
 		str => 12,
 		dex => 6,
 		con => 9,
-		int => 9,
+		intl => 9,
 		wis => 13,
 		cha => 17,
 	}

--- a/lib/OSRIC/Class/Ranger.pm
+++ b/lib/OSRIC/Class/Ranger.pm
@@ -17,7 +17,7 @@ sub minimum_scores
 		str => 13,
 		dex => 6,
 		con => 14,
-		int => 13,
+		intl => 13,
 		wis => 14,
 		cha => 6,
 	}

--- a/lib/OSRIC/Class/Thief.pm
+++ b/lib/OSRIC/Class/Thief.pm
@@ -17,7 +17,7 @@ sub minimum_scores
 		str => 6,
 		dex => 9,
 		con => 6,
-		int => 6,
+		intl => 6,
 		wis => 0,
 		cha => 6,
 	}

--- a/lib/OSRIC/Race/Dwarf.pm
+++ b/lib/OSRIC/Race/Dwarf.pm
@@ -9,7 +9,7 @@ sub stats_boosts
 		str => 0,
 		dex => 0,
 		con => 1,
-		int => 0,
+		intl => 0,
 		wis => 0,
 		cha => -1,
 	}
@@ -45,7 +45,7 @@ sub racial_limitations
 		str => { min => 8, max => 18 },
 		dex => { min => 3, max => 17 },
 		con => { min => 12, max => 19 },
-		int => { min => 3, max => 18 },
+		intl => { min => 3, max => 18 },
 		wis => { min => 3, max => 18 },
 		cha => { min => 3, max => 16 },
 	}

--- a/lib/OSRIC/Race/Elf.pm
+++ b/lib/OSRIC/Race/Elf.pm
@@ -9,7 +9,7 @@ sub stats_boosts
 		str => 0,
 		dex => 1,
 		con => -1,
-		int => 0,
+		intl => 0,
 		wis => 0,
 		cha => 0,
 	}
@@ -46,7 +46,7 @@ sub racial_limitations
 		str => { min => 3, max => 18 },
 		dex => { min => 7, max => 19 },
 		con => { min => 8, max => 17 },
-		int => { min => 8, max => 18 },
+		intl => { min => 8, max => 18 },
 		wis => { min => 3, max => 18 },
 		cha => { min => 3, max => 18 },
 	}

--- a/lib/OSRIC/Race/Gnome.pm
+++ b/lib/OSRIC/Race/Gnome.pm
@@ -9,7 +9,7 @@ sub stats_boosts
 		str => 0,
 		dex => 0,
 		con => 0,
-		int => 0,
+		intl => 0,
 		wis => 0,
 		cha => 0,
 	}
@@ -46,7 +46,7 @@ sub racial_limitations
 		str => { min => 6, max => 18 },
 		dex => { min => 3, max => 19 },
 		con => { min => 8, max => 17 },
-		int => { min => 7, max => 18 },
+		intl => { min => 7, max => 18 },
 		wis => { min => 3, max => 18 },
 		cha => { min => 3, max => 18 },
 	}

--- a/lib/OSRIC/Race/HalfElf.pm
+++ b/lib/OSRIC/Race/HalfElf.pm
@@ -9,7 +9,7 @@ sub stats_boosts
 		str => 0,
 		dex => 0,
 		con => 0,
-		int => 0,
+		intl => 0,
 		wis => 0,
 		cha => 0,
 	}
@@ -49,7 +49,7 @@ sub racial_limitations
 		str => { min => 3, max => 18 },
 		dex => { min => 6, max => 18 },
 		con => { min => 6, max => 18 },
-		int => { min => 4, max => 18 },
+		intl => { min => 4, max => 18 },
 		wis => { min => 3, max => 18 },
 		cha => { min => 3, max => 18 },
 	}

--- a/lib/OSRIC/Race/HalfOrc.pm
+++ b/lib/OSRIC/Race/HalfOrc.pm
@@ -9,7 +9,7 @@ sub stats_boosts
 		str => 1,
 		dex => 0,
 		con => 1,
-		int => 0,
+		intl => 0,
 		wis => 0,
 		cha => -2,
 	}
@@ -46,7 +46,7 @@ sub racial_limitations
 		str => { min => 6, max => 18 },
 		dex => { min => 3, max => 17 },
 		con => { min => 13, max => 19 },
-		int => { min => 3, max => 17 },
+		intl => { min => 3, max => 17 },
 		wis => { min => 3, max => 14 },
 		cha => { min => 3, max => 12 },
 	}

--- a/lib/OSRIC/Race/Halfling.pm
+++ b/lib/OSRIC/Race/Halfling.pm
@@ -9,7 +9,7 @@ sub stats_boosts
 		str => -1,
 		dex => 1,
 		con => 0,
-		int => 0,
+		intl => 0,
 		wis => 0,
 		cha => 0,
 	}
@@ -44,7 +44,7 @@ sub racial_limitations
 		str => { min => 6, max => 17 },
 		dex => { min => 8, max => 19 },
 		con => { min => 10, max => 18 },
-		int => { min => 6, max => 18 },
+		intl => { min => 6, max => 18 },
 		wis => { min => 3, max => 17 },
 		cha => { min => 3, max => 18 },
 	}

--- a/lib/OSRIC/Race/Human.pm
+++ b/lib/OSRIC/Race/Human.pm
@@ -9,7 +9,7 @@ sub stats_boosts
 		str => 0,
 		dex => 0,
 		con => 0,
-		int => 0,
+		intl => 0,
 		wis => 0,
 		cha => 0,
 	}
@@ -46,7 +46,7 @@ sub racial_limitations
 		str => { min => 0, max => 18 },
 		dex => { min => 0, max => 18 },
 		con => { min => 0, max => 18 },
-		int => { min => 0, max => 18 },
+		intl => { min => 0, max => 18 },
 		wis => { min => 0, max => 18 },
 		cha => { min => 0, max => 18 },
 	}


### PR DESCRIPTION
I realise that this isn't something that would be important to this project, because it's meant to be for generating character sheets in general, not irc-osric itself. But, I'll leave this here in case you're interested.
